### PR TITLE
fix: SyncMigrateTableMessage should have the `pa.Schema` argument named as "table"

### DIFF
--- a/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
+++ b/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
@@ -53,7 +53,7 @@ class PluginServicer(plugin_pb2_grpc.PluginServicer):
                     insert=plugin_pb2.Sync.MessageInsert(record=buf)
                 )
             elif isinstance(msg, SyncMigrateTableMessage):
-                buf = arrow.schema_to_bytes(msg.schema)
+                buf = arrow.schema_to_bytes(msg.table)
                 yield plugin_pb2.Sync.Response(
                     migrate_table=plugin_pb2.Sync.MessageMigrateTable(table=buf)
                 )

--- a/cloudquery/sdk/message/sync.py
+++ b/cloudquery/sdk/message/sync.py
@@ -1,15 +1,14 @@
 import pyarrow as pa
 
-
 class SyncMessage:
     pass
 
 
-class SyncInsertMessage:
+class SyncInsertMessage(SyncMessage):
     def __init__(self, record: pa.RecordBatch):
         self.record = record
 
 
-class SyncMigrateTableMessage:
-    def __init__(self, schema: pa.Schema):
-        self.schema = schema
+class SyncMigrateTableMessage(SyncMessage):
+    def __init__(self, table: pa.Schema):
+        self.table = table

--- a/cloudquery/sdk/message/sync.py
+++ b/cloudquery/sdk/message/sync.py
@@ -1,5 +1,6 @@
 import pyarrow as pa
 
+
 class SyncMessage:
     pass
 

--- a/cloudquery/sdk/scheduler/scheduler.py
+++ b/cloudquery/sdk/scheduler/scheduler.py
@@ -163,7 +163,7 @@ class Scheduler:
     ) -> Generator[SyncMessage, None, None]:
         res = queue.Queue()
         for resolver in resolvers:
-            yield SyncMigrateTableMessage(schema=resolver.table.to_arrow_schema())
+            yield SyncMigrateTableMessage(table=resolver.table.to_arrow_schema())
         thread = futures.ThreadPoolExecutor()
         thread.submit(self._sync, client, resolvers, res, deterministic_cq_id)
         total_table_resolvers = 0


### PR DESCRIPTION
This is what the proto expects: https://github.com/cloudquery/plugin-pb/blob/main/plugin/v3/plugin.proto#L68

Having this in another name causes confusion with gRPC (and causes the sync from cli to fail).