### PR TITLE
fix: Fix extension type definitions

### DIFF
--- a/cloudquery/sdk/types/json.py
+++ b/cloudquery/sdk/types/json.py
@@ -1,9 +1,9 @@
 import pyarrow as pa
 
 
-class JSONType(pa.PyExtensionType):
+class JSONType(pa.ExtensionType):
     def __init__(self):
-        pa.PyExtensionType.__init__(self, pa.binary())
+        pa.ExtensionType.__init__(self, extension_name="json", storage_type=pa.binary())
 
     def __reduce__(self):
         return JSONType, ()

--- a/cloudquery/sdk/types/uuid.py
+++ b/cloudquery/sdk/types/uuid.py
@@ -1,9 +1,11 @@
 import pyarrow as pa
 
 
-class UUIDType(pa.PyExtensionType):
+class UUIDType(pa.ExtensionType):
     def __init__(self):
-        pa.PyExtensionType.__init__(self, pa.binary(16))
+        pa.ExtensionType.__init__(
+            self, extension_name="uuid", storage_type=pa.binary(16)
+        )
 
     def __reduce__(self):
         return UUIDType, ()


### PR DESCRIPTION
`PyExtensionType` is a special type for extensions backed by Python pickle, so it's not what we want. We should use the base `ExtensionType`