### PR TITLE
fix(plugin-tables): Add missing `skip_dependent_tables`

### DIFF
--- a/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
+++ b/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
@@ -32,7 +32,11 @@ class PluginServicer(plugin_pb2_grpc.PluginServicer):
 
     def GetTables(self, request: plugin_pb2.GetTables.Request, context):
         tables = self._plugin.get_tables(
-            TableOptions(tables=request.tables, skip_tables=request.skip_tables)
+            TableOptions(
+                tables=request.tables,
+                skip_tables=request.skip_tables,
+                skip_dependent_tables=request.skip_dependent_tables,
+            )
         )
         schema = tables_to_arrow_schemas(tables)
         tablesBytes = []

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ name = "cloudquery-plugin-sdk"
 description = "CloudQuery Plugin SDK for Python"
 
 dependencies = [
-    "cloudquery-plugin-pb==0.0.14",
+    "cloudquery-plugin-pb==0.0.15",
     "exceptiongroup==1.1.2",
     "black==23.7.0",
     "grpcio==1.56.2",


### PR DESCRIPTION
Goes with https://github.com/cloudquery/plugin-pb/pull/17 and https://github.com/cloudquery/plugin-pb-python/pull/14