### PR TITLE
feat: Add support for no_connection param to init

### DIFF
--- a/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
+++ b/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
@@ -1,8 +1,9 @@
+from typing import Generator
+
 import pyarrow as pa
 import structlog
-
-from typing import Generator
 from cloudquery.plugin_v3 import plugin_pb2, plugin_pb2_grpc, arrow
+
 from cloudquery.sdk.message import (
     SyncInsertMessage,
     SyncMigrateTableMessage,
@@ -27,7 +28,7 @@ class PluginServicer(plugin_pb2_grpc.PluginServicer):
         return plugin_pb2.GetVersion.Response(version=self._plugin.version())
 
     def Init(self, request: plugin_pb2.Init.Request, context):
-        self._plugin.init(request.spec)
+        self._plugin.init(request.spec, no_connection=request.no_connection)
         return plugin_pb2.Init.Response()
 
     def GetTables(self, request: plugin_pb2.GetTables.Request, context):

--- a/cloudquery/sdk/plugin/plugin.py
+++ b/cloudquery/sdk/plugin/plugin.py
@@ -1,9 +1,8 @@
-import queue
 from dataclasses import dataclass
 from typing import List, Generator
 
-from cloudquery.sdk.schema import Table
 from cloudquery.sdk import message
+from cloudquery.sdk.schema import Table
 
 MIGRATE_MODE_STRINGS = ["safe", "force"]
 
@@ -35,7 +34,7 @@ class Plugin:
         self._name = name
         self._version = version
 
-    def init(self, spec: bytes) -> None:
+    def init(self, spec: bytes, no_connection: bool = False) -> None:
         pass
 
     def set_logger(self, logger) -> None:


### PR DESCRIPTION
This is required for the cli `tables` option to work without a full spec section for the plugin.