### PR TITLE
fix: Flatten tables in plugin server getTables call

### DIFF
--- a/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
+++ b/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
@@ -14,6 +14,7 @@ from cloudquery.sdk.message import (
 )
 from cloudquery.sdk.plugin.plugin import Plugin, SyncOptions, TableOptions
 from cloudquery.sdk.schema import tables_to_arrow_schemas, Table
+from cloudquery.sdk.schema.table import flatten_tables
 
 
 class PluginServicer(plugin_pb2_grpc.PluginServicer):
@@ -39,7 +40,8 @@ class PluginServicer(plugin_pb2_grpc.PluginServicer):
                 skip_dependent_tables=request.skip_dependent_tables,
             )
         )
-        schema = tables_to_arrow_schemas(tables)
+        flattened_tables = flatten_tables(tables)
+        schema = tables_to_arrow_schemas(flattened_tables)
         tablesBytes = []
         for s in schema:
             sink = pa.BufferOutputStream()
@@ -78,7 +80,7 @@ class PluginServicer(plugin_pb2_grpc.PluginServicer):
         raise NotImplementedError()
 
     def Write(
-        self, request_iterator: Generator[plugin_pb2.Write.Request, None, None], context
+            self, request_iterator: Generator[plugin_pb2.Write.Request, None, None], context
     ):
         def msg_iterator() -> Generator[WriteMessage, None, None]:
             for msg in request_iterator:

--- a/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
+++ b/cloudquery/sdk/internal/servers/plugin_v3/plugin.py
@@ -80,7 +80,7 @@ class PluginServicer(plugin_pb2_grpc.PluginServicer):
         raise NotImplementedError()
 
     def Write(
-            self, request_iterator: Generator[plugin_pb2.Write.Request, None, None], context
+        self, request_iterator: Generator[plugin_pb2.Write.Request, None, None], context
     ):
         def msg_iterator() -> Generator[WriteMessage, None, None]:
             for msg in request_iterator:


### PR DESCRIPTION
Same as the Go implementation, the table list should be flattened before sending it over the wire: https://github.com/cloudquery/plugin-sdk/blob/main/schema/table.go#L204