### PR TITLE
fix: Add --license placeholder for future use

### DIFF
--- a/cloudquery/sdk/serve/plugin.py
+++ b/cloudquery/sdk/serve/plugin.py
@@ -148,6 +148,13 @@ class PluginCommand:
             default="",
             help="Open Telemetry HTTP collector endpoint (for development only) (placeholder for future use)",
         )
+        # ignored for now
+        serve_parser.add_argument(
+            "--license",
+            type=str,
+            default="",
+            help="set offline license file (placeholder for future use)",
+        )
         serve_parser.add_argument(
             "--address",
             type=str,


### PR DESCRIPTION
plugin-pb-go [1.15.0](https://github.com/cloudquery/plugin-pb-go/pull/196) now uses `--license` when invoking plugins, if one is set by the cli.