### PR TITLE
chore: Remove second `package_root`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,8 +34,6 @@ dependencies = [
 ]
 url = "https://github.com/cloudquery/plugin-sdk-python"
 
-package_root = os.path.abspath(os.path.dirname(__file__))
-
 long_description = """
 CloudQuery Plugin SDK for Python
 ================================================


### PR DESCRIPTION
Already present on [line 6](https://github.com/cloudquery/plugin-sdk-python/blob/main/setup.py#L6)

https://github.com/cloudquery/plugin-sdk-python/blob/541e9ca6748d327a9a4f5117ee49695e0f8bb464/setup.py#L6