### PR TITLE
fix: Revert https://github.com/cloudquery/plugin-sdk-python/pull/151

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ dependencies = [
     "protobuf==4.25.3",
     "pyarrow==15.0.2",
     "pytest==8.1.1",
-    "python-dateutil==2.9.0.post0",
+    "python-dateutil==2.8.2",
     "pytz==2024.1",
     "six==1.16.0",
     "structlog==23.3.0",


### PR DESCRIPTION
Reverts https://github.com/cloudquery/plugin-sdk-python/pull/151

Looks like this is not an official version? Also it's blocking https://github.com/cloudquery/cloudquery/actions/runs/8509025446/job/23303751072?pr=17441#step:4:81