### PR TITLE
feat: Log resource when exception occurs to aid debugging

### DIFF
--- a/cloudquery/sdk/scheduler/scheduler.py
+++ b/cloudquery/sdk/scheduler/scheduler.py
@@ -113,9 +113,14 @@ class Scheduler:
                         "failed to resolve resource",
                         client_id=client.id(),
                         table=resolver.table.name,
-                        resource=item,
                         depth=depth,
                         exc_info=e,
+                    )
+                    self._logger.debug(
+                        "details about resource that failed to resolve",
+                        client_id=client.id(),
+                        table=resolver.table.name,
+                        resource=item,
                     )
                     continue
                 res.put(SyncInsertMessage(resource.to_arrow_record()))

--- a/cloudquery/sdk/scheduler/scheduler.py
+++ b/cloudquery/sdk/scheduler/scheduler.py
@@ -113,6 +113,7 @@ class Scheduler:
                         "failed to resolve resource",
                         client_id=client.id(),
                         table=resolver.table.name,
+                        resource=item,
                         depth=depth,
                         exc_info=e,
                     )


### PR DESCRIPTION
This change will allow plugin authors to see the resource that caused the exception, helping them find the underlying cause. To get this level of information, `--log-level debug` needs to be passed to the plugin server (or the CLI, depending on whether or not the plugin is run using the grpc registry)

Closes https://github.com/cloudquery/cloudquery/issues/18002