### PR TITLE
fix: Revert "fix(deps): Update dependency python-dateutil to v2.9.0.post0"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ dependencies = [
     "protobuf==5.27.0",
     "pyarrow==15.0.2",
     "pytest==8.2.1",
-    "python-dateutil==2.9.0.post0",
+    "python-dateutil==2.8.2",
     "pytz==2024.1",
     "six==1.16.0",
     "structlog==23.3.0",


### PR DESCRIPTION
Reverts cloudquery/plugin-sdk-python#182

This is not an official version