### PR TITLE
fix: Relax python-dateutil version requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ dependencies = [
     "protobuf==5.27.2",
     "pyarrow==16.1.0",
     "pytest==8.2.2",
-    "python-dateutil<=2.9.0.post0",
+    "python-dateutil>=2.8.1",
     "pytz==2024.1",
     "six==1.16.0",
     "structlog==24.2.0",

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ dependencies = [
     "protobuf==5.27.2",
     "pyarrow==16.1.0",
     "pytest==8.2.2",
-    "python-dateutil==2.9.0.post0",
+    "python-dateutil<=2.9.0.post0",
     "pytz==2024.1",
     "six==1.16.0",
     "structlog==24.2.0",


### PR DESCRIPTION
This is intended to allow the Square plugin to update to the latest SDK, see https://github.com/cloudquery/cloudquery/actions/runs/9837228486/job/27154578502#step:4:89