### PR TITLE
fix: Don't error when field has no metadata.

### DIFF
--- a/cloudquery/sdk/schema/column.py
+++ b/cloudquery/sdk/schema/column.py
@@ -59,7 +59,7 @@ class Column:
 
     @staticmethod
     def from_arrow_field(field: pa.Field) -> Column:
-        metadata = field.metadata
+        metadata = field.metadata or {}
         primary_key = metadata.get(arrow.METADATA_PRIMARY_KEY) == arrow.METADATA_TRUE
         unique = metadata.get(arrow.METADATA_UNIQUE) == arrow.METADATA_TRUE
         incremental_key = (


### PR DESCRIPTION
I implemented a PoC destination plugin in Python to prove it already supports destination plugins.

It does support them, but I encountered a small bug when processing fields with no metadata. This line errors:

https://github.com/cloudquery/plugin-sdk-python/blob/b3f898ae63385e691d3a493005e8e08103789b40/cloudquery/sdk/schema/column.py#L63

By simply adding an `or {}`, that error is gone.

I was able to implement a file destination in Python and sync XKCD into it:
<img width="1012" alt="Screenshot 2024-08-14 at 16 33 18" src="https://github.com/user-attachments/assets/b5651361-ed7a-42c9-8c09-cdb042e007c0">

```bash
$ cli sync cloudquery-config                            ⏱ 15:58:33
Loading spec(s) from cloudquery-config
Starting sync for: xkcd (cloudquery/xkcd@v1.0.6) -> [file-python (grpc@localhost:7777)]
Sync completed successfully. Resources: 2970, Errors: 0, Warnings: 0, Time: 11s
```