### PR TITLE
chore: Update CODEOWNERS for pnpm/uv migration

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,6 +1,6 @@
 * @cloudquery/backend
 
-requirements.txt
+uv.lock
 setup.py
 .release-please-manifest.json
 CHANGELOG.md


### PR DESCRIPTION
Update CODEOWNERS to reference uv.lock instead of requirements.txt.