### PR TITLE
fix: Exempt pytest from exclude-newer to prevent Renovate PR loop

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,3 +61,4 @@ python_files = "tests/*.py"
 
 [tool.uv]
 exclude-newer = "1 week"
+exclude-newer-package = { pytest = false }


### PR DESCRIPTION
Exempt pytest from the relative `exclude-newer` constraint to stop Renovate from creating duplicate security PRs.